### PR TITLE
test(test_last_newsletters.py): ignore E800

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,11 @@ pycodestyle = [
            # cleaner if we show the actual result without splitting long lines.
 ]
 
+[tool.flakehell.exceptions."tests/unit/services/test_last_newsletters.py"]
+flake8-eradicate = [
+  "-E800", # confuses multi-line markdown string as commented out code
+]
+
 # --------- Pylint -------------
 [tool.pylint.'TYPECHECK']
 generated-members = "sh"


### PR DESCRIPTION
Necessary since it confuses multi-line MarkDown string with commented out code.
